### PR TITLE
Fix typo in design.md: "togehter" -> "together"

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -36,7 +36,7 @@ In this case, the Bundling and Auctioneer responsibilities are conducted by the 
 
 ## Domain Data Model
 
-The Atlas data model primarily consists of 3 different types of Operations which togehter are combined into a Bundle that is signed into a transaction:
+The Atlas data model primarily consists of 3 different types of Operations which together are combined into a Bundle that is signed into a transaction:
 
 ![Data model](/docs/data-model.png "Data model")
 


### PR DESCRIPTION
Fixed a spelling error in the domain data model section of docs/design.md, where "togehter" was incorrectly written instead of "together".